### PR TITLE
*physx*

### DIFF
--- a/code/render/physics/physx/physxphysicsserver.cc
+++ b/code/render/physics/physx/physxphysicsserver.cc
@@ -171,11 +171,13 @@ PhysXServer::onTrigger(PxTriggerPair* pairs, PxU32 count)
 	this->critSect.Enter();
 	for (PxU32 i = 0; i < count;i++)
 	{
-		n_assert(pairs[i].triggerActor->userData && ((Core::RefCounted*)pairs[i].triggerActor->userData)->IsA(Physics::PhysicsProbe::RTTI));
-		PhysX::PhysXProbe * probe = (PhysX::PhysXProbe*)pairs[i].triggerActor->userData;
-		if (!pairs[i].flags.isSet(PxTriggerPairFlag::eDELETED_SHAPE_OTHER) && pairs[i].otherActor->userData)
+		if (!pairs[i].flags.isSet(PxTriggerPairFlag::eDELETED_SHAPE_OTHER) && !pairs[i].flags.isSet(PxTriggerPairFlag::eREMOVED_SHAPE_TRIGGER))
 		{
-			probe->OnTriggerEvent(pairs[i].status, pairs[i].otherActor);
+			PhysX::PhysXProbe * probe = (PhysX::PhysXProbe*)pairs[i].triggerActor->userData;
+			if (pairs[i].otherActor->userData)
+			{
+				probe->OnTriggerEvent(pairs[i].status, pairs[i].otherActor);
+			}
 		}
 	}
 	this->critSect.Leave();

--- a/code/render/physics/physx/physxprobe.cc
+++ b/code/render/physics/physx/physxprobe.cc
@@ -149,8 +149,11 @@ PhysXProbe::OnTriggerEvent(PxPairFlag::Enum eventType, physx::PxActor * other)
 void
 PhysXProbe::SetTransform(const Math::matrix44 & trans)
 {
-	BaseProbe::SetTransform(trans);
-	this->body->setGlobalPose(Neb2PxTrans(trans));
+	PhysicsObject::SetTransform(trans);
+	// physx does not allow rescaling of a trigger, ignore all but position
+	physx::PxTransform ptrans = this->body->getGlobalPose();
+	ptrans.p = Neb2PxVec(trans.get_position());
+	this->body->setGlobalPose(ptrans);
 }
 
 }


### PR DESCRIPTION
- ignore scale and rotation in triggers when receiving settransform messages
- ignore trigger callbacks for removed objects/triggers
