### PR TITLE
 *posteffects* *network*

### DIFF
--- a/code/addons/multiplayer/lannetworkserver.cc
+++ b/code/addons/multiplayer/lannetworkserver.cc
@@ -116,9 +116,9 @@ LanNetworkServer::ShutdownLowlevelNetworking()
 */
 void
 LanNetworkServer::Close()
-{
-	delete this->fullyConnectedMesh;
+{	
 	NetworkServer::Close();	
+	delete this->fullyConnectedMesh;
 }
 
 //------------------------------------------------------------------------------

--- a/code/addons/posteffect/posteffectfeatureunit.cc
+++ b/code/addons/posteffect/posteffectfeatureunit.cc
@@ -126,6 +126,7 @@ PostEffectFeatureUnit::SetupDefaultWorld()
 void
 PostEffectFeatureUnit::CleanupDefaultWorld()
 {	
+	PostEffect::PostEffectServer::Instance()->StopAllBlending();
 	Ptr<Graphics::Stage> stage = GraphicsFeature::GraphicsFeatureUnit::Instance()->GetDefaultStage();
 	if (stage.isvalid())
 	{

--- a/code/addons/posteffect/rt/posteffectserver.cc
+++ b/code/addons/posteffect/rt/posteffectserver.cc
@@ -439,7 +439,7 @@ PostEffectServer::ApplySkyParameters()
     // get textures
     const Ptr<SkyParams>& targetPara = this->postEffects[Sky].target.cast<SkyParams>();
     const Ptr<SkyParams>& currentPara = this->postEffects[Sky].current.cast<SkyParams>();
-
+	
 	// preload textures
 	this->PreloadTexture(targetPara->GetSkyTexturePath());
 	this->PreloadTexture(currentPara->GetSkyTexturePath());
@@ -626,5 +626,16 @@ PostEffectServer::SetSkyEntity( const Ptr<Graphics::ModelEntity>& entity )
 	this->skyEntity->SetAlwaysVisible(true);
 }
 
+//------------------------------------------------------------------------------
+/**
+*/
+void
+PostEffectServer::StopAllBlending()
+{
+	for (int i = 0; i < this->postEffects.Size(); i++)
+	{
+		this->postEffects[i].target = 0;
+	}
+}
 
 } // namespace PostEffect

--- a/code/addons/posteffect/rt/posteffectserver.h
+++ b/code/addons/posteffect/rt/posteffectserver.h
@@ -94,6 +94,8 @@ public:
     void StartBlending(const Ptr<ParamBase>& target, Timing::Time fadeTime, PostEffectType postEffectType);
     /// stops blending for specified effect
     void StopBlending(PostEffectType postEffectType);
+	/// stop all blending operations
+	void StopAllBlending();
 
 	/// set the sky entity
 	void SetSkyEntity(const Ptr<Graphics::ModelEntity>& entity);


### PR DESCRIPTION
- stop blending when reseting world in posteffectsfeatureunit - dont delete fully connected mesh before shutting down base network services
